### PR TITLE
Add direct parallel port connection type

### DIFF
--- a/inkcut/device/dialogs.enaml
+++ b/inkcut/device/dialogs.enaml
@@ -106,7 +106,9 @@ enamldef DeviceDialog(Dialog): dialog:
                             Label:
                                 text = tr("device", "Type")
                             ObjectCombo:
-                                items << device.transports if device and device.transports else plugin.transports
+                                items << sorted(
+                                    device.transports if device and device.transports else plugin.transports,
+                                    key=lambda t: t.name)
                                 to_string = lambda t: t.name
                                 #selected << (connection.declaration
                                 #             if connection  else None)

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -1029,6 +1029,7 @@ class DevicePlugin(Plugin):
             from .transports.serialport.manifest import SerialManifest
             from .transports.printer.manifest import PrinterManifest
             from .transports.disk.manifest import FileManifest
+            from .transports.parallelport.manifest import ParallelManifest
             from inkcut.device.protocols.manifest import ProtocolManifest
             from inkcut.device.drivers.manifest import DriversManifest
             from inkcut.device.filters.manifest import FiltersManifest
@@ -1037,6 +1038,7 @@ class DevicePlugin(Plugin):
             plugins.append(SerialManifest)
             plugins.append(PrinterManifest)
             plugins.append(FileManifest)
+            plugins.append(ParallelManifest)
             plugins.append(ProtocolManifest)
             plugins.append(DriversManifest)
             plugins.append(FiltersManifest)

--- a/inkcut/device/transports/parallelport/manifest.enaml
+++ b/inkcut/device/transports/parallelport/manifest.enaml
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2019, Jairus Martin.
+
+Distributed under the terms of the GPL v3 License.
+
+The full license is in the file LICENSE, distributed with this software.
+
+Created on June 7, 2019
+
+@author: jrm
+"""
+import enaml
+from enaml.workbench.api import Extension
+from enaml.workbench.plugin_manifest import PluginManifest
+from inkcut.device.extensions import DeviceTransport, DEVICE_TRANSPORT_POINT
+
+def transport_factory(driver, declaration, protocol):
+    from .plugin import ParallelTransport, ParallelConfig
+    config = ParallelConfig(**driver.get_connection_config('parallel'))
+    return ParallelTransport(
+        declaration=declaration, protocol=protocol, config=config)
+
+
+def config_view_factory():
+    with enaml.imports():
+        from .settings import ParallelPortSettingsView
+    return ParallelPortSettingsView
+
+
+def plugin_factory():
+    from .plugin import ParallelPlugin
+    return ParallelPlugin()
+
+
+enamldef ParallelManifest(PluginManifest):
+    id = 'inkcut.device.transport.parallelport'
+    factory = plugin_factory
+    Extension:
+        id = 'transports'
+        point = DEVICE_TRANSPORT_POINT
+
+        DeviceTransport:
+            id = 'parallel'
+            name = 'Parallel Port'
+            factory = transport_factory
+            config_view = config_view_factory

--- a/inkcut/device/transports/parallelport/plugin.py
+++ b/inkcut/device/transports/parallelport/plugin.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2019, Jairus Martin.
+
+Distributed under the terms of the GPL v3 License.
+
+The full license is in the file LICENSE, distributed with this software.
+
+Created on June 7, 2019
+
+@author: jrm
+"""
+import re
+import sys
+import traceback
+import subprocess
+from glob import glob
+from atom.api import Atom, List, Unicode, Instance
+from inkcut.core.api import Plugin, log
+
+from inkcut.device.transports.raw.plugin import (
+    RawFdTransport, RawFdProtocol, RawFdConfig
+)
+
+
+class ParallelPortDescriptor(Atom):
+    name = Unicode()
+    device = Unicode()
+
+    def __str__(self):
+        return "{} ({})".format(self.name, self.device)
+
+
+def find_dev_name(dev):
+    """ Use udevadm to lookup info on a device
+
+    Parameters
+    ----------
+    dev: String
+        The device path to lookup, eg /dev/usb/lp1
+
+    Returns
+    -------
+    name: String
+        The device name
+
+    """
+    try:
+        cmd = 'udevadm info -a %s' % dev
+        manufacturer = ""
+        product = ""
+
+        output = subprocess.check_output(cmd.split())
+        if sys.version_info.major > 2:
+            output = output.decode()
+        for line in output.split('\n'):
+            log.debug(line)
+            m = re.search(r'ATTRS{(.+)}=="(.+)"', line)
+            if m:
+                k, v = m.groups()
+                if k == 'manufacturer':
+                    manufacturer = v.strip()
+                elif k == 'product':
+                    product = v.strip()
+            if manufacturer and product:
+                return '{} {}'.format(manufacturer, product)
+        log.warning('Could not lookup device info for %s' % dev)
+    except Exception as e:
+        tb = traceback.format_exc()
+        log.warning('Could not lookup device info for %s  %s' % (dev, tb))
+    return 'usb%s' % dev.split('/')[-1]
+
+
+def find_ports():
+    """ Lookup ports from known locations on the system
+
+    Returns
+    -------
+    ports: List[ParallelPortDescriptor]
+        The ports found on the system
+
+    """
+    ports = []
+    if 'win32' in sys.platform:
+        pass  # TODO
+    elif 'darwin' in sys.platform:
+        pass  # TODO
+    else:
+        for p in glob('/dev/lp*'):
+            # TODO: Get friendly device name
+            name = p.split('/')[-1]
+            ports.append(ParallelPortDescriptor(device=p, name=name))
+
+        for p in glob('/dev/parport*'):
+            # TODO: Get friendly device name
+            name = p.split('/')[-1]
+            ports.append(ParallelPortDescriptor(device=p, name=name))
+
+        for p in glob('/dev/usb/lp*'):
+            name = find_dev_name(p)
+            ports.append(ParallelPortDescriptor(device=p, name=name))
+
+    return ports
+
+
+class ParallelConfig(RawFdConfig):
+    #: Available serial ports
+    ports = List(ParallelPortDescriptor)
+
+    # -------------------------------------------------------------------------
+    # Defaults
+    # -------------------------------------------------------------------------
+    def _default_ports(self):
+        return find_ports()
+
+    def _default_device_path(self):
+        if self.ports:
+            return self.ports[0].device
+        return ""
+
+    def refresh(self):
+        self.ports = self._default_ports()
+
+
+class ParallelTransport(RawFdTransport):
+    """ This is just a wrapper for the RawFdTransport
+
+    """
+    #: Default config
+    config = Instance(ParallelConfig, ()).tag(config=True)
+
+
+class ParallelPlugin(Plugin):
+    """ Plugin for handling parallel port communication
+
+    """

--- a/inkcut/device/transports/parallelport/settings.enaml
+++ b/inkcut/device/transports/parallelport/settings.enaml
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright (c) 2019, Jairus Martin.
+
+Distributed under the terms of the GPL v3 License.
+
+The full license is in the file LICENSE, distributed with this software.
+
+Created on June 7, 2019
+
+@author: jrm
+"""
+import textwrap
+from inkcut.core.utils import load_icon
+from enaml.layout.api import hbox, align, spacer
+from enaml.widgets.api import Container, Form, Label, ObjectCombo, SpinBox, CheckBox, PushButton
+
+
+enamldef ParallelPortSettingsView(Container):
+    attr model
+    padding = 0
+
+    func selected_port(port, ports):
+        matches = [p for p in ports if p.device == port]
+        return matches[0] if matches else None
+
+    Form:
+        Label:
+            text = "Port"
+        Container:
+            padding = 0
+            constraints = [
+                hbox(cb, pb),
+                align('v_center', cb, pb)
+            ]
+            ObjectCombo: cb:
+                items << model.ports
+                selected << selected_port(model.device_path, model.ports)
+                selected ::
+                    port = change['value']
+                    if port:
+                        model.port = port.device
+                tool_tip = textwrap.dedent("""
+                List of parallel ports detected by the system. If nothing is here you
+                must install the device driver for your machine.
+                """).strip()
+            PushButton: pb:
+                text = "Refresh"
+                icon = load_icon("arrow_refresh")
+                clicked :: model.refresh()


### PR DESCRIPTION
For #25 and #117 . Works on linux. Collects info on usb/printers using `udevadm` . 

The user must be added to the `lp` group via `sudo usermod -a -G lp your-username`

Would be nice to be able get info for non-usb parallel ports.

Also thoughts on dropping cups stuff altogether (or making it an optional install)?