### PR TITLE
supported-devices.md: Add parallel port for pii-60

### DIFF
--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -188,6 +188,7 @@
 |Vinyl Express       |lynx                          |Serial    |24        |Unlimited           |Yes    |
 |Vinyl Express       |lynx                          |Serial    |24        |Unlimited           |No     |
 |Vinyl Express       |pii-60                        |Serial    |24        |Unlimited           |Yes    |
+|Vinyl Express       |pii-60                        |Printer   |24        |Unlimited           |Yes    |
 |Vinyl Express       |QE60+                         |Printer   |24        |Unlimited           |Yes    |
 |Vinyl Express       |qe600                         |Serial    |24        |24                  |Yes    |
 |Vinyl Express       |R 31                          |Printer   |79        |Unlimited           |Yes    |


### PR DESCRIPTION
Inkcut can (also) communicate with the pii-60 plotter via the parallel port.