### PR TITLE
Add hack to patch pyserial error

### DIFF
--- a/inkcut/device/transports/serialport/plugin.py
+++ b/inkcut/device/transports/serialport/plugin.py
@@ -28,6 +28,27 @@ from inkcut.device.transports.raw.plugin import RawFdTransport, RawFdProtocol
 SERIAL_PARITIES = {v: k for k, v in serial.PARITY_NAMES.items()}
 
 
+def patch_pyserial_if_needed():
+    """ A workaround for
+    https://github.com/pyserial/pyserial/issues/286
+    """
+    try:
+        from serial.tools.list_ports_common import ListPortInfo
+    except ImportError:
+        return
+    try:
+        dummy = ListPortInfo()
+        dummy == None
+        log.debug("pyserial patch not needed")
+    except AttributeError:
+        def __eq__(self, other):
+            return isinstance(other, ListPortInfo) \
+                and self.device == other.device
+        ListPortInfo.__eq__ = __eq__
+        log.debug("pyserial patched")
+patch_pyserial_if_needed()
+
+
 class SerialConfig(Model):
     #: Available serial ports
     ports = List()
@@ -119,4 +140,3 @@ class SerialPlugin(Plugin):
     # -------------------------------------------------------------------------
     # SerialPlugin API
     # -------------------------------------------------------------------------
-


### PR DESCRIPTION
A hack to workaround for https://github.com/pyserial/pyserial/issues/286 since pyserial they seem to not want to do any more releases. 

Should fix https://github.com/inkcut/inkcut/issues/163, https://github.com/inkcut/inkcut/issues/171, 