### PR TITLE
Fix #247 : set return code so ResourceWarning is not emited with pyth…

### DIFF
--- a/plugins/inkscape/inkcut_cut.py
+++ b/plugins/inkscape/inkcut_cut.py
@@ -81,6 +81,12 @@ class InkscapeInkcutPlugin(inkex.Effect):
                              close_fds=sys.platform != "win32")
         p.stdin.write(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
         p.stdin.close()
+        
+        # Set the returncode to avoid this warning when popen is garbage collected:
+        # "ResourceWarning: subprocess XXX is still running".
+        # See https://bugs.python.org/issue38890 and
+        # https://bugs.python.org/issue26741.
+        p.returncode = 0
 
 if VERSION == "1.X":
     if __name__ == '__main__':

--- a/plugins/inkscape/inkcut_open.py
+++ b/plugins/inkscape/inkcut_open.py
@@ -71,7 +71,11 @@ class InkscapeInkcutPlugin(inkex.Effect):
                              close_fds=sys.platform != "win32")
         p.stdin.write(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
         p.stdin.close()
-
+        # Set the returncode to avoid this warning when popen is garbage collected:
+        # "ResourceWarning: subprocess XXX is still running".
+        # See https://bugs.python.org/issue38890 and
+        # https://bugs.python.org/issue26741.
+        p.returncode = 0
 
 if VERSION == "1.X":
     if __name__ == '__main__':


### PR DESCRIPTION
…on >3.5

This fix the ResourceWarning now emitted by Popen with a process is still running when ending python script.
I tested it with python 3.8