### PR TITLE
Shows a double problem with the optimize Shortest Path :

### DIFF
--- a/inkcut/job/ordering.py
+++ b/inkcut/job/ordering.py
@@ -92,7 +92,7 @@ class OrderShortestPath(OrderHandler):
 
     """
     name = 'Shortest Path'
-    time_limit = 0.2  # This is in the UI thread
+    time_limit = 30.0  # This is in the UI thread
 
     def order(self, job, path):
         """ Sort subpaths by minimizing the distances between all start
@@ -116,6 +116,7 @@ class OrderShortestPath(OrderHandler):
         original = subpaths[:]
         result = []
         p = zero
+        now=time()
         while subpaths:
             best = sys.maxsize
             shortest = None
@@ -132,8 +133,9 @@ class OrderShortestPath(OrderHandler):
             # time.time() is slow so limit the calls
             if time() > time_limit:
                 result.extend(subpaths)  # At least part of it is optimized
-                log.debug("Shortest path search aborted (time limit reached)")
+                log.warning("Shortest path search aborted (time limit reached)")
                 break
+        log.warning("=== SHORTEST PATH COMPUTE DURATION = %02f",time()-now)
         d = self.subpath_move_distance(zero, original)
         d = d-self.subpath_move_distance(zero, result)
         log.debug("Shortest path search: Saved {} in of movement ".format(


### PR DESCRIPTION
1/ 0.2 second is way too low for my computer, a basic laptop. The
drawing is fairly complicated and unordered (Kicad schematic)
It requires at least 6 seconds to do it.

2/ The next problem is this function is called unnecessarily each time a
tuning like 'Orientation' is updated. Why ? It has been optimized and
should not be lost (or calling the optimized path again should not take
the same time.

I have no idea where to fix problem 2/  Line 138 just shows it.

'Warning' is better than debug for the message line 135. 

2020-06-05 17:58:27,180 | WARNING | inkcut | === SHORTEST PATH COMPUTE DURATION = 5.443059
2020-06-05 17:58:27,206 | INFO    | inkcut | {'type': 'update', 'object': <inkcut.job.models.Job object at 0x7f2ed8bcd0c8>, 'name': 'model', 'oldvalue': <PyQt5.QtGui.QPainterPath object at 0x7f2ebdd68668>, 'value': <PyQt5.QtGui.QPainterPath object at 0x7f2ebb3d30b8>}
2020-06-05 17:58:27,287 | INFO    | inkcut | Saving state due to change: {'type': 'request'}
2020-06-05 17:58:55,088 | WARNING | inkcut | === SHORTEST PATH COMPUTE DURATION = 5.452136
2020-06-05 17:58:55,115 | INFO    | inkcut | {'type': 'update', 'object': <inkcut.job.models.Job object at 0x7f2ed8bcd0c8>, 'name': 'model', 'oldvalue': <PyQt5.QtGui.QPainterPath object at 0x7f2ebb3d30b8>, 'value': <PyQt5.QtGui.QPainterPath object at 0x7f2ed8c2cd68>}
2020-06-05 17:58:55,198 | INFO    | inkcut | Saving state due to change: {'type': 'request'}
2020-06-05 17:59:00,868 | WARNING | inkcut | === SHORTEST PATH COMPUTE DURATION = 5.511186
2020-06-05 17:59:00,895 | INFO    | inkcut | {'type': 'update', 'object': <inkcut.job.models.Job object at 0x7f2ed8bcd0c8>, 'name': 'model', 'oldvalue': <PyQt5.QtGui.QPainterPath object at 0x7f2ed8c2cd68>, 'value': <PyQt5.QtGui.QPainterPath object at 0x7f2ed8c09898>}
2020-06-05 17:59:00,978 | INFO    | inkcut | Saving state due to change: {'type': 'request'}