### PR TITLE
[Inkscape plugin] use Popen.communicate instead of deprecated stdin.w…

### DIFF
--- a/plugins/inkscape/inkcut_cut.py
+++ b/plugins/inkscape/inkcut_cut.py
@@ -79,8 +79,9 @@ class InkscapeInkcutPlugin(inkex.Effect):
                              stdout=DEVNULL,
                              stderr=subprocess.STDOUT,
                              close_fds=sys.platform != "win32")
-        p.stdin.write(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
-        p.stdin.close()
+        (stdout, stderr) = p.communicate(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
+        if p.returncode != 0:
+            inkex.errormsg("Error while starting inkcut : " + str(p.returncode) + " please check inkcut path.")
         
         # Set the returncode to avoid this warning when popen is garbage collected:
         # "ResourceWarning: subprocess XXX is still running".

--- a/plugins/inkscape/inkcut_open.py
+++ b/plugins/inkscape/inkcut_open.py
@@ -69,8 +69,9 @@ class InkscapeInkcutPlugin(inkex.Effect):
                              stdout=DEVNULL,
                              stderr=subprocess.STDOUT,
                              close_fds=sys.platform != "win32")
-        p.stdin.write(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
-        p.stdin.close()
+       (stdout, stderr) = p.communicate(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
+        if p.returncode != 0:
+            inkex.errormsg("Error while starting inkcut : " + str(p.returncode) + " please check inkcut path.")
         # Set the returncode to avoid this warning when popen is garbage collected:
         # "ResourceWarning: subprocess XXX is still running".
         # See https://bugs.python.org/issue38890 and

--- a/plugins/inkscape/inkcut_open.py
+++ b/plugins/inkscape/inkcut_open.py
@@ -69,7 +69,7 @@ class InkscapeInkcutPlugin(inkex.Effect):
                              stdout=DEVNULL,
                              stderr=subprocess.STDOUT,
                              close_fds=sys.platform != "win32")
-       (stdout, stderr) = p.communicate(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
+        (stdout, stderr) = p.communicate(etree.tostring(document) if VERSION == "1.X" else inkex.etree.tostring(document))
         if p.returncode != 0:
             inkex.errormsg("Error while starting inkcut : " + str(p.returncode) + " please check inkcut path.")
         # Set the returncode to avoid this warning when popen is garbage collected:


### PR DESCRIPTION
stdin.write is deprecated, use communicate instead which handle the .close(), also add error message if something wrong about inkcut path