### PR TITLE
Avoid name clash between inkscape plugin and inkcut itself

### DIFF
--- a/plugins/inkscape/inkcut4inkscape.py
+++ b/plugins/inkscape/inkcut4inkscape.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 Inkcut, Plot HPGL directly from Inkscape.
-   inkcut.py
+   inkcut4inkscape.py
 
    Copyright 2018 The Inkcut Team
 

--- a/plugins/inkscape/inkcut_cut.inx
+++ b/plugins/inkscape/inkcut_cut.inx
@@ -2,7 +2,7 @@
   <_name>Cut selection...</_name>
   <id>org.ekips.filter.inkcut.cut</id>
   <dependency type="executable" location="extensions">inkcut_cut.py</dependency>
-  <dependency type="executable" location="extensions">inkcut.py</dependency>
+  <dependency type="executable" location="extensions">inkcut4inkscape.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>  
   <effect>
     <object-type>all</object-type>

--- a/plugins/inkscape/inkcut_cut.py
+++ b/plugins/inkscape/inkcut_cut.py
@@ -37,7 +37,7 @@ if VERSION == "1.X":
 else:
     inkex.localize()
 import subprocess
-from inkcut import contains_text, convert_objects_to_paths
+from inkcut4inkscape import contains_text, convert_objects_to_paths
 
 
 

--- a/plugins/inkscape/inkcut_open.inx
+++ b/plugins/inkscape/inkcut_open.inx
@@ -2,7 +2,7 @@
   <_name>Open current document...</_name>
   <id>org.ekips.filter.inkcut.open</id>
   <dependency type="executable" location="extensions">inkcut_open.py</dependency>
-  <dependency type="executable" location="extensions">inkcut.py</dependency>
+  <dependency type="executable" location="extensions">inkcut4inkscape.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>  
   <effect>
     <object-type>all</object-type>

--- a/plugins/inkscape/inkcut_open.py
+++ b/plugins/inkscape/inkcut_open.py
@@ -38,7 +38,7 @@ else:
     inkex.localize()
 import subprocess
 
-from inkcut import convert_objects_to_paths
+from inkcut4inkscape import convert_objects_to_paths
 
 DEBUG = False
 try:


### PR DESCRIPTION
Ohterwise, with an unfortunate PYTONPATH, inkcut would no longer
start since it'd try to use inkcut.py from the extension
instead of the application itself...