### PR TITLE
Workaround: Use qtpy 1.11.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 enaml>=0.10.2
+qtpy<=1.11.3
 twisted
 enamlx
 pyqtgraph


### PR DESCRIPTION
Don't use qtpy version 2.0.0 to keep qt4 compatibility. This is needed for enamlx, see #321.