### PR TITLE
inkscape extension: no inkex.py dependency

### DIFF
--- a/plugins/inkscape/inkcut_cut.inx
+++ b/plugins/inkscape/inkcut_cut.inx
@@ -3,7 +3,6 @@
   <id>org.ekips.filter.inkcut.cut</id>
   <dependency type="executable" location="extensions">inkcut_cut.py</dependency>
   <dependency type="executable" location="extensions">inkcut4inkscape.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>  
   <effect>
     <object-type>all</object-type>
     <effects-menu>

--- a/plugins/inkscape/inkcut_open.inx
+++ b/plugins/inkscape/inkcut_open.inx
@@ -3,7 +3,6 @@
   <id>org.ekips.filter.inkcut.open</id>
   <dependency type="executable" location="extensions">inkcut_open.py</dependency>
   <dependency type="executable" location="extensions">inkcut4inkscape.py</dependency>
-  <dependency type="executable" location="extensions">inkex.py</dependency>  
   <effect>
     <object-type>all</object-type>
     <effects-menu>


### PR DESCRIPTION
Don't specify inkex.py as a dependency: this is not needed, and
from inkscape 1.2 onwards this file does not exist anymore
(https://gitlab.com/inkscape/extensions/-/merge_requests/460)

Fixes #339 