### PR TITLE
Make gcode protocol more configurable.

### DIFF
--- a/inkcut/device/protocols/gcode.py
+++ b/inkcut/device/protocols/gcode.py
@@ -4,19 +4,82 @@ Created on Dec 30, 2016
 
 @author: jrm
 """
-from inkcut.device.plugin import DeviceProtocol
+from inkcut.device.plugin import DeviceProtocol, Model
+from enaml.qt.QtCore import QT_TRANSLATE_NOOP
+from atom.api import (
+    Bool, Float, Enum, Int, Instance, Str
+)
 
+class GCodeConfig(Model):
+    use_builtin = Bool(True).tag(config=True)
+
+    TOOL_LIFT_IMPLICIT = 0 # assume that device will lift/lower tool based on G00 / G01
+    TOOL_LIFT_CUSTOM = 1 # user specified GCODE
+    TOOL_LIFT_Z = 2 # move Z axis on 3 axis machine
+
+
+    # QT_TRANSLATE_NOOP("protocols", "Implicit")
+    tool_lift_modes = {
+        TOOL_LIFT_IMPLICIT: QT_TRANSLATE_NOOP("protocols", "Implicit"),
+        TOOL_LIFT_CUSTOM: QT_TRANSLATE_NOOP("protocols", "Custom"),
+        TOOL_LIFT_Z: QT_TRANSLATE_NOOP("protocols", "Z"),
+    }
+
+    lift_mode = Enum(*tool_lift_modes.keys()).tag(config=True)
+    precision = Int(0).tag(config=True)
+
+    lower_z = Float(0).tag(config=True)
+    upper_z = Float(1).tag(config=True)
+
+    lift_gcode = Str().tag(config=True)
+    lower_gcode = Str().tag(config=True)
 
 class GCodeProtocol(DeviceProtocol):
 
+    config = Instance(GCodeConfig, ()).tag(config=True)
+
+    _currently_up = Bool()
+    scale = 1 # Float(25.4/90)
+
+    def send_command_block(self, commands):
+        if commands:
+            if not commands.endswith("\n"):
+                self.write(commands + "\n")
+            else:
+                self.write(commands)
+
+    def _lift(self):
+        if self.config.lift_mode == GCodeConfig.TOOL_LIFT_CUSTOM:
+            self.send_command_block(self.config.lift_gcode)
+
+    def _lower(self):
+        if self.config.lift_mode == GCodeConfig.TOOL_LIFT_CUSTOM:
+            self.send_command_block(self.config.lower_gcode)
+
     def connection_made(self):
-        self.write("G28; Return to home\n")
-        self.write("G98; Return to initial z\n")
-        self.write("G90; Use absolute coordinates\n")
+        if self.config.use_builtin:
+            self.write("G28; Return to home\n")
+            self.write("G98; Return to initial z\n")
+            self.write("G90; Use absolute coordinates\n")
     
     def move(self, x, y, z, absolute=True):
-        self.write("G0%i X%i Y%i;\n" % (z, x, y))
-        
+        if self._currently_up != (z == 0):
+            if self._currently_up:
+                self._lower()
+            else:
+                self._lift()
+            if z == 0:
+                self._currently_up = True
+            else:
+                self._currently_up = False
+        x, y = x * self.scale, y * self.scale
+        line = "G0{:d} X{:.{precision}f} Y{:.{precision}f}".format(z, x, y, precision=self.config.precision)
+        if self.config.lift_mode == GCodeConfig.TOOL_LIFT_Z:
+            physical_z = self.config.lower_z if z == 1 else self.config.upper_z
+            line += " Z{:.{precision}f}".format(physical_z, precision=self.config.precision)
+        line += "\n"
+        self.write(line)
+
     def set_force(self, f):
         raise NotImplementedError
         
@@ -27,8 +90,9 @@ class GCodeProtocol(DeviceProtocol):
         raise NotImplementedError
 
     def finish(self):
-        self.write("G28; Return to home\n")
-        self.write("G98; Return to initial z\n")
+        if self.config.use_builtin:
+            self.write("G28; Return to home\n")
+            self.write("G98; Return to initial z\n")
 
     def connection_lost(self):
         pass

--- a/inkcut/device/protocols/manifest.enaml
+++ b/inkcut/device/protocols/manifest.enaml
@@ -38,9 +38,13 @@ def cammgl1_factory(driver, declaration):
 
 
 def gcode_factory(driver, declaration):
-    from .gcode import GCodeProtocol
-    return GCodeProtocol(declaration=declaration)
+    from .gcode import GCodeProtocol, GCodeConfig
+    return GCodeProtocol(declaration=declaration, config=GCodeConfig(**driver.get_protocol_config('gcode')))
 
+def gcode_config_view():
+    with enaml.imports():
+        from .view import GCodeConfigView
+    return GCodeConfigView
 
 def mock_factory(driver, declaration):
     from .debug import DebugProtocol
@@ -85,6 +89,7 @@ enamldef ProtocolManifest(PluginManifest):
             id = 'gcode'
             name = 'G-Code'
             factory = gcode_factory
+            config_view = gcode_config_view
 
         DeviceProtocol:
             id = 'debug'

--- a/inkcut/device/protocols/view.enaml
+++ b/inkcut/device/protocols/view.enaml
@@ -10,10 +10,11 @@ Created on Dec 11, 2017
 
 @author: jrm
 """
-from enaml.widgets.api import Container, Label, ObjectCombo
+from enaml.core.api import Conditional
+from enaml.widgets.api import Container, Form, Label, ObjectCombo, SpinBox, MultilineField, CheckBox
+from enamlx.widgets.api import DoubleSpinBox
 from enaml.qt.QtWidgets import QApplication
-
-
+from .gcode import GCodeConfig
 
 enamldef DMPLConfigView(Container):
     attr model
@@ -24,7 +25,65 @@ enamldef DMPLConfigView(Container):
         selected := model.mode
 
 
-enamldef CAMMConfigView(Container):
+enamldef GCodeConfigView(Container):
+    attr model
+    Form:
+        Label:
+            pass
+        CheckBox:
+            text = QApplication.translate("protocols", "Use builtin startup/end commands")
+            checked := model.use_builtin
+            tool_tip = QApplication.translate("protocols", "When disabled make sure to specify after connect, before and after job commands in device settings")
+        Label:
+            text = QApplication.translate("protocols", "Decimal precision")
+        SpinBox:
+            value := model.precision
+            minimum = 0
+            maximum = 10
+        Label:
+            text = QApplication.translate("protocols", "Lift mode")
+        ObjectCombo:
+            items  = list(GCodeConfig.tool_lift_modes.items())
+            to_string = lambda obj: QApplication.translate("protocols", obj[1])
+            selected << (model.lift_mode, GCodeConfig.tool_lift_modes[model.lift_mode])
+            selected ::
+                    item = change['value']
+                    if item:
+                        model.lift_mode = item[0]
+        Conditional:
+            condition << model.lift_mode == GCodeConfig.TOOL_LIFT_Z
+            Label:
+                text = QApplication.translate("protocols", "Lower Z")
+            DoubleSpinBox:
+                value := model.lower_z
+                decimals = 6
+                minimum = -9999.9
+                maximum = 9999.9
+                tool_tip =  QApplication.translate("protocols", "Z position when tool is in writing position")
+            Label:
+                text = QApplication.translate("protocols", "Upper Z")
+            DoubleSpinBox:
+                value := model.upper_z
+                decimals = 6
+                minimum = -9999.9
+                maximum = 9999.9
+                tool_tip =  QApplication.translate("protocols", "Z position when tool is lifted above material")
+        Conditional:
+            condition << model.lift_mode == GCodeConfig.TOOL_LIFT_CUSTOM
+            Label:
+                text = QApplication.translate("protocols", "Raise G-Code")
+            MultilineField:
+                   text := model.lift_gcode
+                   tool_tip = QApplication.translate("protocols", "Commands here will get sent when tool needs to be lifted away from material")
+            Label:
+                text = QApplication.translate("protocols", "Lower G-Code")
+            MultilineField:
+                   text := model.lower_gcode
+                   tool_tip = QApplication.translate("protocols", "Commands here will get sent when starting to draw a line")
+        
+
+
+enamldef DMPLConfigView(Container):
     attr model
     Label:
         text = QApplication.translate("protocols", "Mode")


### PR DESCRIPTION
**Description**

Exact set of G-code commands varies between different devices, controller/firmware manufacturers.  There are also a lot of DIY devices potentially requiring very specific startup sequences or creative approaches for activating the tool.

Add protocol configuration for following properties
* decimal precision (#301)
* configurable tool lifting code (Implicit, Custom, Z)
* disabling builtin startup sequence


I tried to write the new code so that in default configuration, everything works just like it did before.

Tool lifting choice works like this:
* Implict -> assumes that device automatically lifts the tool for G00 moves and lowers it for G01
* Custom -> user can define custom G-code to execute when tool needs to be activated or deactivated. Useful for DIY devices using something like servo or pneumatic outputs for moving the tool.
* Z -> moves the Z axis on 3 axis machine for engaging the tool with material 

**Things I want to ask main developers**
* I am not familiar with enaml so let me know if I used appropriate way for storing protocol state. 
* If there are some project style guide that I didn't follow please point me to it.
* Does the current DeviceDriver system allows specifying protocol properties? -> it seemed to work, unlike bunch of other default_config properties

**Related issues**

Closes #301