### PR TITLE
Use selected units in job aproval and live view.

### DIFF
--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -279,9 +279,9 @@ enamldef DeviceProgressDockItem(DockItem):
                 text << "Source: {}".format(job)
             Label: lbl2:
                 text << "Size: {}{} x {}{}".format(
-                        round(to_unit(job.model.boundingRect().height(), job.info.units),2),
+                        round(to_unit(job.model.boundingRect().height(), job_plugin.units),2),
                         job_plugin.units,
-                        round(to_unit(job.model.boundingRect().width(), job.info.units), 2),
+                        round(to_unit(job.model.boundingRect().width(), job_plugin.units), 2),
                         job_plugin.units
                     ) if job and job.model else ""
             Label: lbl3:

--- a/inkcut/job/dialogs.enaml
+++ b/inkcut/job/dialogs.enaml
@@ -31,6 +31,7 @@ enamldef JobApprovalDialog(Dialog): dialog:
     initial_size = (640, 320)
     attr plugin
     attr device = plugin.workbench.get_plugin('inkcut.device').device
+    attr job_plugin << plugin.workbench.get_plugin('inkcut.job')
     attr job: Job
     Conditional:
         # Only use this if not using the system theme
@@ -70,10 +71,10 @@ enamldef JobApprovalDialog(Dialog): dialog:
                     tool_tip = QApplication.translate("job", "Estimated material usage")
                 Label:
                     text << "Size: {}{} x {}{}".format(
-                            round(to_unit(job.model.boundingRect().height(), job.info.units),2),
-                            job.info.units,
-                            round(to_unit(job.model.boundingRect().width(), job.info.units), 2),
-                            job.info.units
+                            round(to_unit(job.model.boundingRect().height(), job_plugin.units),2),
+                            job_plugin.units,
+                            round(to_unit(job.model.boundingRect().width(), job_plugin.units), 2),
+                            job_plugin.units
                         )
 #                Label:
 #                    text = QApplication.translate("job", "Cost")

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -93,9 +93,6 @@ class JobInfo(Model):
     #: Estimates based on length and speed
     duration = Instance(timedelta, ()).tag(config=True)
 
-    #: Units
-    units = Enum('in', 'cm', 'm', 'ft').tag(config=True)
-
     #: Callback to open the approval dialog
     auto_approve = Bool().tag(config=True)
     request_approval = Callable()


### PR DESCRIPTION
Use the units from "Settings/Settings/Job" in job approval window and Live view.

Previously approval window always used inches, but live view used numerical value of inches  with unit suffix from settings.

Closes #319 