### PR TITLE
Fix for qtSerialPort on Windows with hardware flow control closing the port and stopping the job before it's finished

### DIFF
--- a/inkcut/device/transports/qtserialport/plugin.py
+++ b/inkcut/device/transports/qtserialport/plugin.py
@@ -145,9 +145,10 @@ class QtSerialTransport(DeviceTransport):
             data = data.encode()
         self.last_write = data
         self.connection.write(data)
-        
+        self.connection.waitForBytesWritten(-1)
     def disconnect(self):
         if self.connection:
+            self.connection.waitForBytesWritten(-1)
             log.debug("-- {} | closed by request".format(self.device_path))
             self.connected=False
             self.connection.close()


### PR DESCRIPTION
This fixes some of the problems mentioned in #306 and potentially the ones in #182 where people are using qtSerialPort with hardware flow control. Personally the suggested fix in #182 with filling lots of garbage data at the end of a job is very much a kludge, and doesn't solve the root cause of the problem.

To me it seems that some plotters (mine!) stops the job when the computer indicates that the port is closed. If this happens before all of the data is written to the device, you will be missing something.

It could possibly also be a good idea to do a small delay between the flush and the close, but I haven't implemented that. This patch just waits for bytes to be written after each write, and also does a wait for bytes to be written before closing the port.

This solved the same kind of problems for my MH721 plotter under Windows.