### PR TITLE
Fix handling of last curve.

### DIFF
--- a/inkcut/core/utils.py
+++ b/inkcut/core/utils.py
@@ -164,7 +164,7 @@ def split_painter_path(path):
             params.append(QPointF(e.x, e.y))
 
     # Finish the previous curve (if there was one)
-    if params and e and e.type != CurveToDataElement:
+    if params:
         finish_curve(p, params)
     return subpaths
 


### PR DESCRIPTION
Logic bug in how `split_painter_path` handles last curve caused it to not be included. This was observable when using plotting order modes other than normal or reversed.

Blade offset had same bug, but wasn't able to trigger it because at that stage of processing last curve was always followed by linear movement, even when input only contains one or two curves. Probably some kind of connection move. Still fixed it since it didn't seem like good idea to rely on it.

Before:
![Screenshot from 2022-10-15 15-59-47](https://user-images.githubusercontent.com/7101031/195988436-41d6d54d-ad49-421a-b2c0-8c6bdd6f0366.png)
After:
![Screenshot from 2022-10-15 16-15-29](https://user-images.githubusercontent.com/7101031/195988446-196c9cc2-9c7a-430d-8257-23eebc37d6da.png)

Test file:
[drawing4.zip](https://github.com/inkcut/inkcut/files/9792144/drawing4.zip)
