### PR TITLE
Rework device creation to use all the data from driver.

### DIFF
--- a/inkcut/device/dialogs.enaml
+++ b/inkcut/device/dialogs.enaml
@@ -11,6 +11,7 @@ Created on Jul 14, 2015
 """
 from enaml.core.api import Conditional, Include, Looper
 from enaml.layout.api import align, hbox, spacer
+from enaml.stdlib.dialog_buttons import DialogButtonBox, DialogButton
 from enaml.stdlib.task_dialog import (
     TaskDialogBody, TaskDialogCommandArea,
     TaskDialogContentArea, TaskDialogDetailsArea, TaskDialogFootnoteArea,
@@ -25,7 +26,7 @@ from enamlx.widgets.api import (
     TreeView, TreeViewItem, TreeViewColumn, DoubleSpinBox
 )
 
-from .plugin import Device, DeviceConfig
+from .plugin import Device, DeviceConfig, DeviceProtocol
 from .view import ConfigView, DeviceConfigView
 from inkcut.core.api import Model
 from inkcut.core.utils import to_unit, from_unit, load_icon
@@ -63,16 +64,9 @@ enamldef DeviceEditView(Notebook): notebook:
                     text := device.name
                 Label:
                     text = QApplication.translate("device", "Driver")
-                ObjectCombo:
-                    items << plugin.drivers
-                    to_string = lambda d: QApplication.translate("device", d.id)
-                    attr selected_driver << [d for d in plugin.drivers if d.id == driver.id]
-                    selected << selected_driver[0] if selected_driver else None
-                    selected ::
-                        driver = selected
-                        device.declaration = driver
-                        device.manufacturer = driver.manufacturer
-                        device.model = driver.model
+                Field:
+                    text << QApplication.translate("device", driver.id)
+                    read_only = True
                 Label:
                     text = QApplication.translate("device", "Manufacturer")
                 Field:
@@ -214,6 +208,28 @@ enamldef DeviceEditView(Notebook): notebook:
                                 ] if current_filter and current_filter.config else []
 
 
+enamldef NewDeviceDialog(Dialog): dialog:
+    attr plugin
+    attr resultDriver = plugin.drivers[0]
+    title = QApplication.translate("device", "New device")
+    TaskDialogBody:
+        TaskDialogInstructionArea:
+            Label:
+                text = QApplication.translate("device", "Select device")
+        TaskDialogContentArea:
+            Label:
+                text = QApplication.translate("device", "Driver:")
+            ObjectCombo:
+                    items << plugin.drivers
+                    to_string = lambda d: QApplication.translate("device", d.id)
+                    selected >> dialog.resultDriver
+        TaskDialogCommandArea:
+            DialogButtonBox: bbox:
+                buttons = [
+                    DialogButton('OK', 'accept'),
+                    DialogButton('Cancel', 'reject'),
+                ]
+
 enamldef DeviceDialog(Dialog): dialog:
     title = QApplication.translate("device", "Configure device")
     initial_size = (640, 320)
@@ -226,9 +242,21 @@ enamldef DeviceDialog(Dialog): dialog:
             plugin.device = devices[0]
             plugin.devices = devices
 
-    func add_device():
+    func copy_device(device):
+        new_dev = device.clone(plugin)
+        new_dev.name += " " + QApplication.translate("device", "copy")
         devices = plugin.devices[:]
-        new_dev = plugin.get_device_from_driver(plugin.drivers[0])
+        devices.append(new_dev)
+        plugin.devices = devices
+
+    func add_device():
+        selection = NewDeviceDialog(self, plugin=plugin) 
+        accepted = selection.exec_()
+        if not accepted:
+            return
+        devices = plugin.devices[:]
+        new_dev = plugin.get_device_from_driver(selection.resultDriver)
+        new_dev.name = new_dev.name + " " + selection.resultDriver.id
         devices.append(new_dev)
         plugin.device = new_dev
         plugin.devices = devices
@@ -288,6 +316,9 @@ enamldef DeviceDialog(Dialog): dialog:
                                         Action:
                                             text = QApplication.translate("device", "Remove")
                                             triggered :: remove_device(loop_item)
+                                        Action:
+                                            text = QApplication.translate("device", "Copy")
+                                            triggered :: copy_device(loop_item)
                         PushButton:
                             icon = load_icon('add')
                             text = QApplication.translate("device", "Add")

--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -35,6 +35,7 @@ enamldef DriversManifest(PluginManifest):
         DeviceDriver:
             manufacturer = 'Inkcut'
             model = 'Generic Driver'
+            custom = True
 
         DeviceDriver:
             manufacturer = 'Vinylmark'

--- a/inkcut/device/extensions.py
+++ b/inkcut/device/extensions.py
@@ -11,7 +11,7 @@ Created on Jan 16, 2015
 @author: jrm
 """
 import enaml
-from atom.api import Str, List, Callable, Dict
+from atom.api import Str, List, Callable, Dict, Bool
 from inkcut.core.declarative import Declarative, d_
 
 DEVICE_DRIVER_POINT = 'inkcut.device.driver'
@@ -20,7 +20,7 @@ DEVICE_TRANSPORT_POINT = 'inkcut.device.transport'
 DEVICE_FILTER_POINT = 'inkcut.device.filters'
 
 
-def default_device_factory(driver, transports, protocols):
+def default_device_factory(driver, transports, protocols, config=None):
     """ Generates a device if none is given by the driver.
     Parameters
     ----------
@@ -37,10 +37,12 @@ def default_device_factory(driver, transports, protocols):
         A configured Device that the application can use.
     """
     from .plugin import Device, DeviceConfig
+    if not config:
+        config = DeviceConfig(**driver.get_device_config())
     return Device(declaration=driver,
                   transports=transports,
                   protocols=protocols,
-                  config=DeviceConfig(**driver.get_device_config()))
+                  config=config)
 
 
 def default_device_config_view_factory():
@@ -62,6 +64,9 @@ class DeviceDriver(Declarative):
 
     #: Name of the device (optional)
     name = d_(Str())
+
+    # whether user wants to use default model, width and length
+    custom =  d_(Bool(False))
 
     #: Model of the device (optional)
     model = d_(Str())

--- a/inkcut/device/pi/manifest.enaml
+++ b/inkcut/device/pi/manifest.enaml
@@ -16,11 +16,13 @@ from enaml.workbench.api import Extension
 from inkcut.device.extensions import DeviceDriver
 
 
-def device_factory(driver, transports, protocols):
+def device_factory(driver, transports, protocols, config=None):
     """ Import our custom device driver """
     from .driver import PiDevice, PiConfig
+    if not config:
+        config = PiConfig(**driver.default_config)
     return PiDevice(declaration=driver, transports=transports, protocols=protocols,
-                    config=PiConfig(**driver.default_config))
+                    config=config)
 
 
 def config_view_factory():


### PR DESCRIPTION
* add UI for choosing driver before device is created
* disable driver switching after device is created
* add command for copying a device

In theory the driver switching after device is created can't work for general case where the specific driver 'DeviceDriver(Declarative)' has custom factory which creates some `Device(Model)` subclass like it is for PiDevice. In practice it doesn't properly work even in the simple cases as indicated by #282 .  Switching driver after device has been created also introduces problem of how to deal with user modified fields which conflict with values from driver manifest, or cases where you are switching between devices with different set of supported protocols.

Copying functionality is useful if you want to create multiple slightly different configs for the same device. Ideally a device could have multiple configuration profiles, but copying can serve as reasonable substitute before that. For now copying doesn't handle filters but I didn't touch that here since they have their own problems and I am working on that in separate branch.  I am not to happy about the implementation of device copying itself especially connection and protocol config handling. If anyone has ideas how to do it in cleaner and more idiomatic way I am open to suggestions.

![image](https://user-images.githubusercontent.com/7101031/200177997-0d4239c1-bdc7-4c9c-991b-c0be7ad821f8.png)


Closes  #282