### PR TITLE
Fix device area cloning.

### DIFF
--- a/inkcut/core/models.py
+++ b/inkcut/core/models.py
@@ -88,6 +88,12 @@ class AreaBase(Model):
         p.addRect(self.available_area)
         return p
 
+    def clone(self):
+        result = AreaBase()
+        result.size = self.size
+        result.padding = self.padding
+        return result
+
     @observe('size', 'padding')
     def _sync_size(self, change):
         self.area.setWidth(self.size[0])

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -493,7 +493,7 @@ class Device(Model):
         new_dev.name = self.name
         new_dev.manufacturer = self.manufacturer
         new_dev.model = self.model
-        new_dev.area = self.area
+        new_dev.area = self.area.clone()
         new_dev.custom = self.custom
         if driver.factory:
             connection_decl = self.connection.declaration


### PR DESCRIPTION
Prevented unintended sharing of device area property when copying a device.

Closes #360 