### PR TITLE
Add optional newline terminator for HPGL.

### DIFF
--- a/inkcut/device/protocols/hpgl.py
+++ b/inkcut/device/protocols/hpgl.py
@@ -4,13 +4,26 @@ Created on Jul 25, 2015
 
 @author: jrm
 """
-from atom.api import Float, Bool, Int
-from inkcut.device.plugin import DeviceProtocol
+from atom.api import Instance, Float, Bool, Int
+from inkcut.device.plugin import DeviceProtocol, Model
 from inkcut.core.utils import log
+
+
+class HPGLConfig(Model):
+    #: Pad option
+    pad = Bool().tag(config=True)
 
 
 class HPGLProtocol(DeviceProtocol):
     scale = Float(1021/90.0)
+
+    #: Pad option
+    config = Instance(HPGLConfig, ()).tag(config=True)
+
+    def write(self, data):
+        if self.config.pad:
+            data += "\n"
+        super().write(data)
 
     def connection_made(self):
         #: Initialize in absoulte mode

--- a/inkcut/device/protocols/manifest.enaml
+++ b/inkcut/device/protocols/manifest.enaml
@@ -32,6 +32,12 @@ def dmpl_config_view():
     return DMPLConfigView
 
 
+def hpgl_config_view():
+    with enaml.imports():
+        from .view import HPGLConfigView
+    return HPGLConfigView
+
+
 def cammgl1_factory(driver, declaration):
     from .camm import CAMMGL1Protocol
     return CAMMGL1Protocol(declaration=declaration)
@@ -73,6 +79,7 @@ enamldef ProtocolManifest(PluginManifest):
             id = 'hpgl'
             name = 'HPGL'
             factory = hpgl_factory
+            config_view = hpgl_config_view
 
         DeviceProtocol:
             id = 'dmpl'

--- a/inkcut/device/protocols/view.enaml
+++ b/inkcut/device/protocols/view.enaml
@@ -90,3 +90,13 @@ enamldef DMPLConfigView(Container):
     ObjectCombo:
         items  = list(model.get_member('mode').items)
         selected := model.mode
+
+
+enamldef HPGLConfigView(Container):
+    attr model
+    Label:
+        text = QApplication.translate("protocols",
+                                      "Pad commands with line feed")
+    CheckBox:
+        checked := model.pad
+        text = QApplication.translate("protocols", "Enable")


### PR DESCRIPTION
Intended for use with USB-connected plotters that need a little padding between commands.

Tested on US Cutter MH365 MK2.

fixes #367