### PR TITLE
Restore broken monitor functionality.

### DIFF
--- a/inkcut/monitor/view.enaml
+++ b/inkcut/monitor/view.enaml
@@ -13,7 +13,7 @@ from enaml.qt.QtCore import Qt
 from enaml.qt.QtWidgets import QApplication, QPlainTextEdit
 from enaml.qt.QtGui import QTextCursor
 from enaml.widgets.api import  (
-    Container, RawWidget, Field, PushButton, ObjectCombo
+    Action, Container, RawWidget, Field, PushButton, ObjectCombo, Menu
 )
 from enaml.application import deferred_call
 from enaml.layout.api import vbox, align, hbox
@@ -68,6 +68,7 @@ enamldef MonitorDockItem(DockItem): view:
         try:
             msg = change['value'].decode()
             widget.insertPlainText(msg.strip() if plugin.strip_whitespace else msg)
+            scroll_to_end()
         except:
             pass  # Ignore decode errors
 
@@ -77,6 +78,7 @@ enamldef MonitorDockItem(DockItem): view:
         widget = comm_log.proxy.widget
         try:
             msg = change['value'].decode()
+            msg = msg.remove('\r')
             widget.appendPlainText(msg.strip() if plugin.strip_whitespace else msg)
         except:
             pass  # Ignore decode errors
@@ -109,6 +111,13 @@ enamldef MonitorDockItem(DockItem): view:
                 plugin.history.pop(0)
         # Reset
         view.history_index = 0
+
+    Menu:
+        context_menu = True
+        Action:
+            text = QApplication.translate('monitor', "Add newline")
+            checkable = True
+            checked := plugin.add_newline
 
     Container:
         constraints = [


### PR DESCRIPTION
* Add UI for enabling "add newline" functionality.  The functionality was already there, but from what I could tell there was no way to enable it. 
* Fix scroll to end . I assume it got accidentally removed in https://github.com/inkcut/inkcut/commit/218571f3e4ba8c015d02011bb1c6f3c3287096b5 . In case the scrolling was one of the reasons for slowdown, it's always possible to disable it.
* remove \r from output from output field. This was causing response from device not to show up properly.