### PR TITLE
Fix shebang

### DIFF
--- a/plugins/inkscape/inkcut4inkscape.py
+++ b/plugins/inkscape/inkcut4inkscape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Inkcut, Plot HPGL directly from Inkscape.

--- a/plugins/inkscape/inkcut_cut.py
+++ b/plugins/inkscape/inkcut_cut.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Inkcut, Plot HPGL directly from Inkscape.

--- a/plugins/inkscape/inkcut_open.py
+++ b/plugins/inkscape/inkcut_open.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Inkcut, Plot HPGL directly from Inkscape.


### PR DESCRIPTION
According to PEP 304 scripts should continue to use "python3":

> Even as the Python 2 interpreter becomes less common, it remains reasonable
> for scripts to continue to use the python3 convention, rather than just
> python.