### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/inkcut/ui/plugin.py
+++ b/inkcut/ui/plugin.py
@@ -11,7 +11,7 @@ Created on Jul 12, 2015
 """
 import sys
 import enaml
-import pkg_resources
+import importlib.metadata
 from datetime import datetime
 from atom.api import Atom, Int, List, Str, Instance, Bool, Enum, Dict
 from enaml.qt.q_resource_helpers import get_cached_qicon
@@ -112,8 +112,8 @@ class InkcutPlugin(Plugin):
             plugins.append(MonitorManifest)
 
             #: Load any plugins defined as extension points
-            for entry_point in pkg_resources.iter_entry_points(
-                    group='inkcut.plugin', name=None):
+            for entry_point in importlib.metadata.entry_points(
+                    group='inkcut.plugin'):
                 plugins.append(entry_point.load())
 
         #: Install all of them


### PR DESCRIPTION
`pkg_resource` is deprecated and is removed in Pyhton 3.12.

Note: This would raise the required Python version to Python 3.8. If compatibility with earlier Python versions is required, we could use the `importlib_metadata` backport package (see [here](https://setuptools.pypa.io/en/latest/pkg_resources.html)). Python 2 compatibility would be broken never the less, but  Python 2 is EOL since 2020 and all support for this legacy version could be removed.