### PR TITLE
Use raw string for regex

### DIFF
--- a/inkcut/core/svg.py
+++ b/inkcut/core/svg.py
@@ -170,7 +170,7 @@ class QtSvgItem(QPainterPath):
             return t
 
         m = re.match(
-            "(translate|scale|rotate|skewX|skewY|matrix)\s*\(([^)]*)\)\s*,?",
+            r"(translate|scale|rotate|skewX|skewY|matrix)\s*\(([^)]*)\)\s*,?",
             trans)
         if m is None:
             return t


### PR DESCRIPTION
Using unescaped backslash escape sequences in string literals will cause a `DeprecationWarning` (< 3.12) or a `SyntaxWarning` (3.12+).