### PR TITLE
Don't use prefix `_default_` if no member exists

### DIFF
--- a/inkcut/device/dialogs.enaml
+++ b/inkcut/device/dialogs.enaml
@@ -270,7 +270,7 @@ enamldef DeviceDialog(Dialog): dialog:
         if not dev.connection:
             dev.connection = dev._default_connection()
         if not dev.connection.protocol:
-            dev.connection.protocol = dev._default_protocol()
+            dev.connection.protocol = dev._create_default_protocol()
         if dev not in plugin.devices:
             plugin.devices.append(dev)
         plugin.device = dev

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -414,10 +414,10 @@ class Device(Model):
             return TestTransport()
         declaration = self.transports[0]
         driver = self.declaration
-        protocol = self._default_protocol()
+        protocol = self._create_default_protocol()
         return declaration.factory(driver, declaration, protocol)
 
-    def _default_protocol(self):
+    def _create_default_protocol(self):
         """ Create the protocol for this device. """
         if not self.protocols:
             return DeviceProtocol()


### PR DESCRIPTION
The prefix `_default_` is reserved for methods generating the default value for an attribute (in atom). If we are using the method `_default_protocol` without a member `protocol`, a MissingMemberWarning will be generated:

```
atom/meta/atom_meta.py:555: MissingMemberWarning: _default_ method _default_protocol on class 'Device' does not match any member defined on the Atom object.
```